### PR TITLE
feat: Added OpenAI Embedding Functionality

### DIFF
--- a/src/chains/mapreduce/mod.rs
+++ b/src/chains/mapreduce/mod.rs
@@ -73,6 +73,7 @@ mod tests {
     #[ignore = "wip"]
     async fn test_mapreduce() {
         let client = Arc::new(OpenAI::new());
+        #[allow(unused_variables)]
         let map_chain = Arc::new(Mutex::new(LLMChain::new(client.clone(), "Hello, {name}!")));
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -9,9 +9,7 @@ use anyhow::Result;
 use candle_core::{Device, Result as CandleResult, Tensor};
 
 use crate::prompt::Prompt;
-use crate::record::Record;
-
-use self::openai::{OpenAI, OpenAIEmbeddingResponse};
+use self::openai::OpenAIEmbeddingResponse;
 
 /// Generate with context trait is used to execute an LLM using a context and a prompt template.
 /// The context is a previously created context using the Context struct. The prompt template
@@ -53,7 +51,7 @@ pub trait LLM: Sync + Send {
 
 /// Embedding trait is used to generate an embedding from an Online Service.
 #[async_trait::async_trait]
-pub trait EMBEDDING: Sync + Send {
+pub trait Embedding: Sync + Send {
     /// Generate an embedding from an Online Service.
     /// # Arguments
     /// * `input` - A Record trait object.
@@ -73,7 +71,7 @@ pub trait EMBEDDING: Sync + Send {
     ///    assert!(response.to_string().to_lowercase().contains("paris"));
     /// }
     /// ```
-    async fn generate_embedding<'a>(&'a self, input: &'a Record) -> Result<OpenAIEmbeddingResponse>;
+    async fn generate_embedding(&self, prompt: Box<dyn Prompt>) -> Result<OpenAIEmbeddingResponse>;
 }
 
 #[derive(Debug)]

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -8,8 +8,8 @@ use std::fmt::Display;
 use anyhow::Result;
 use candle_core::{Device, Result as CandleResult, Tensor};
 
-use crate::prompt::Prompt;
 use self::openai::OpenAIEmbeddingResponse;
+use crate::prompt::Prompt;
 
 /// Generate with context trait is used to execute an LLM using a context and a prompt template.
 /// The context is a previously created context using the Context struct. The prompt template

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -8,7 +8,6 @@ use std::fmt::Display;
 use anyhow::Result;
 use candle_core::{Device, Result as CandleResult, Tensor};
 
-use self::openai::OpenAIEmbeddingResponse;
 use crate::prompt::Prompt;
 
 /// Generate with context trait is used to execute an LLM using a context and a prompt template.
@@ -59,6 +58,7 @@ pub trait Embedding: Sync + Send {
     /// # Examples
     /// This example uses the OpenAI chat models.
     /// ```
+    /// use orca::prompt;
     /// use orca::llm::Embedding;
     /// use orca::record::Record;
     /// use orca::llm::openai::OpenAI;
@@ -66,12 +66,12 @@ pub trait Embedding: Sync + Send {
     /// #[tokio::main]
     /// async fn main() {
     ///    let client = OpenAI::new();
-    ///    let input = Record::new("Hello, world");
-    ///    let response = client.generate_embedding(&input).await.unwrap();
-    ///    assert!(response.to_string().to_lowercase().contains("paris"));
+    ///    let input = prompt!("Hello, world");
+    ///    let response = client.generate_embedding(input).await.unwrap();
+    ///    assert!(response.get_embedding().len() > 0);
     /// }
     /// ```
-    async fn generate_embedding(&self, prompt: Box<dyn Prompt>) -> Result<OpenAIEmbeddingResponse>;
+    async fn generate_embedding(&self, prompt: Box<dyn Prompt>) -> Result<EmbeddingResponse>;
 }
 
 #[derive(Debug)]

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -144,7 +144,7 @@ impl Default for OpenAI {
         Self {
             client: Client::new(),
             url: OPENAI_COMPLETIONS_URL.to_string(),
-            api_key: "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".to_string(),
+            api_key: std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"),
             model: "gpt-3.5-turbo".to_string(),
             emedding_model: "text-embedding-ada-002".to_string(),
             temperature: 1.0,

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -266,6 +266,7 @@ impl EmbeddingTrait for OpenAI {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::prompt;
     use crate::prompt::TemplateEngine;
     use crate::template;
     use std::collections::HashMap;
@@ -299,8 +300,8 @@ mod test {
     #[tokio::test]
     async fn test_embeddings() {
         let client = OpenAI::new();
-        let content = "This is a test".to_string();
-        let res = client.generate_embedding(Box::new(content)).await.unwrap();
+        let content = prompt!("This is a test");
+        let res = client.generate_embedding(content).await.unwrap();
         assert!(res.data[0].embedding.len() > 0);
     }
 }

--- a/src/llm/openai.rs
+++ b/src/llm/openai.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
-use super::LLMResponse;
+use super::{EmbeddingResponse, LLMResponse};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Payload {
@@ -254,7 +254,7 @@ impl LLM for OpenAI {
 
 #[async_trait::async_trait]
 impl EmbeddingTrait for OpenAI {
-    async fn generate_embedding<'a>(&'a self, prompt: Box<dyn Prompt>) -> Result<OpenAIEmbeddingResponse> {
+    async fn generate_embedding<'a>(&'a self, prompt: Box<dyn Prompt>) -> Result<EmbeddingResponse> {
         let req = self.generate_embedding_request(prompt.as_str()?)?;
         let res = self.client.execute(req).await?;
         let res = res.json::<OpenAIEmbeddingResponse>().await?;
@@ -302,6 +302,6 @@ mod test {
         let client = OpenAI::new();
         let content = prompt!("This is a test");
         let res = client.generate_embedding(content).await.unwrap();
-        assert!(res.data[0].embedding.len() > 0);
+        assert!(res.get_embedding().len() > 0);
     }
 }


### PR DESCRIPTION
Hi @santiagomed, I love your Rust LLM Framework so far! and I would be happy to help contribute I was planning to use it for my Master's thesis and I was just wondering if I could add OpenAI's embeddings. 

I just have one small issue you might be able to help with, for some reason the Embeddings payload isn't being attached to the request! You can replicate this by running 

```cargo test test_embeddings -- --nocapture```
